### PR TITLE
Gpu preparation

### DIFF
--- a/activity_classifier.ipynb
+++ b/activity_classifier.ipynb
@@ -115,7 +115,9 @@
    "metadata": {},
    "source": [
     "### 2. **Build the model**\n",
-    "We use the `tc.activity_classifier.create` function and specify the data, target variable (the activity label), session_id, and a few other arguments needed to properly train the model. To understand more about this specific function, check out the [Turi Create Documentation](https://apple.github.io/turicreate/docs/userguide/activity_classifier/)."
+    "We use the `tc.activity_classifier.create` function and specify the data, target variable (the activity label), session_id, and a few other arguments needed to properly train the model. To understand more about this specific function, check out the [Turi Create Documentation](https://apple.github.io/turicreate/docs/userguide/activity_classifier/).\n",
+    "\n",
+    "**Interested in trying a GPU?** [Read more about deploying a job using a GPU](https://docs.metismachine.io/v1.3.1/docs/using-a-gpu)."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-skafossdk==1.2.1
-mxnet-cu80==1.1.0.post0
+skafossdk==1.2.2
 turicreate==5.3.1
+mxnet==1.1.0
+mxnet-cu80==1.1.0
 pandas==0.23.4

--- a/utilities/dependencies.py
+++ b/utilities/dependencies.py
@@ -4,23 +4,24 @@ import sys
 from subprocess import check_output
 
 
-def _try_install(timeout):
+def _requirements(timeout):
     try:
-        # try installing, give it 3 mins to try and install 
+        # try installing, give it 3 mins to try and install
         output = check_output(["pip", "install", "-r", "/home/jovyan/requirements.txt"], timeout=timeout)
-        
     except Exception as e:
         print(f"Exception encountered while installing dependencies: {e}", flush=True)
         raise e
 
 def install(timeout=300, retries=2):
     # Install all dependencies inside requirements.txt
-    print("Checking and installing required python dependencies in requirements.txt", flush=True)
-    try:
-        _try_install(timeout)
-        # Load pkg directly from site-packages (avoid restart kernel)  
-        if not os.path.exists(".local/site-packages/"):
-            os.makedirs(".local/site-packages/")
-        sys.path.append(".local/site-packages/")
-    except Exception as e:
-        raise e
+    if os.path.exists("/home/jovyan/"):
+        print("Checking and installing required python dependencies in requirements.txt", flush=True)
+        try:
+            _requirements(timeout)
+            # Load pkg directly from site-packages (avoid restart kernel)
+            if not os.path.exists(".local/site-packages/"):
+                os.makedirs(".local/site-packages/")
+            sys.path.append(".local/site-packages/")
+        except Exception as e:
+            raise e
+        print("Done", flush=True)


### PR DESCRIPTION
- update requirements
- add comments to notebook
- new dependency module

## Instructions for testing
1. Login to production Skafos dashboard.
2. Open up an existing Activity Classifier project created not too long ago. OR create a new standard Activity Classifier project from the dashboard.
3. Launch JLab.
4. Open Terminal and run the following to get the code to test:
```bash
$ git remote add origin https://github.com/skafos/TuriActivityClassifier.git
$ git fetch origin
$ git reset --hard origin/master
$ git merge gpu-prep
```
5. Open skafos JSON config and swap cpu/memory requests and limits to:
`"nvidia.com/gpu": 1`. Check config details here: https://docs.metismachine.io/v1.3.1/docs/using-a-gpu
6. Save config and hit deploy.
7. Job should run successfully and train a thing.